### PR TITLE
Fix handling of `gengen.Yield()` arguments

### DIFF
--- a/cmd/gengen/wizard.go
+++ b/cmd/gengen/wizard.go
@@ -315,14 +315,15 @@ func (wiz *FuncWizard) VisitCallExpr(node *ast.CallExpr) string {
 			if len(node.Args) != 1 {
 				log.Fatal("Yield accepts a single argument.")
 			}
-			var yieldValue bytes.Buffer
-			format.Node(&yieldValue, wiz.pkg.Fset, node.Args[0])
+			fmt.Println("Arg:", node.Args[0])
+			yieldValue := wiz.convertAst(node.Args[0])
+			fmt.Println("<-Arg:", node.Args[0])
 
 			yield, err := wiz.Render("yield", struct {
 				YieldValue string
 				Next       int
 			}{
-				YieldValue: yieldValue.String(),
+				YieldValue: yieldValue,
 				Next:       wiz.NextIndex(),
 			})
 			if err != nil {
@@ -352,15 +353,23 @@ func (wiz *FuncWizard) VisitIdent(node *ast.Ident) string {
 	}
 	definition, exists := wiz.pkg.TypesInfo.Defs[node]
 	if exists {
-		return wiz.DefineVariable(definition)
+		fmt.Println("exists", node)
+		name := wiz.DefineVariable(definition)
+		fmt.Println("as", name)
+		return name
 	}
+	fmt.Println("ident-node", node)
 	usage, exists := wiz.pkg.TypesInfo.Uses[node]
+	fmt.Println(usage, wiz.pkg.Fset.Position(usage.Pos()))
 	if _, isBuiltin := usage.(*types.Builtin); isBuiltin {
 		return node.String()
 	}
 	if exists && usage.Pkg() != nil && usage.Pkg().Path() == wiz.pkg.PkgPath {
-		return wiz.GetVariable(usage)
+		name := wiz.GetVariable(usage)
+		fmt.Println("Name", name)
+		return name
 	}
+	fmt.Println("node.string", node.String())
 	return node.String()
 }
 func (wiz *FuncWizard) VisitAssignStmt(node *ast.AssignStmt) string {

--- a/cmd/gengen/wizard.go
+++ b/cmd/gengen/wizard.go
@@ -640,6 +640,11 @@ func (wiz *FuncWizard) VisitArrayType(node *ast.ArrayType) string {
 	}
 	return arrType.String()
 }
+
+func (wiz *FuncWizard) VisitIndexExpr(node *ast.IndexExpr) string {
+	return wiz.convertAst(node.X) + "[" + wiz.convertAst(node.Index) + "]"
+}
+
 func (wiz *FuncWizard) convertAst(node ast.Node) string {
 	if node == nil {
 		// This saves some work with conditionally-nil nodes.

--- a/cmd/gengen/wizard.go
+++ b/cmd/gengen/wizard.go
@@ -315,9 +315,7 @@ func (wiz *FuncWizard) VisitCallExpr(node *ast.CallExpr) string {
 			if len(node.Args) != 1 {
 				log.Fatal("Yield accepts a single argument.")
 			}
-			fmt.Println("Arg:", node.Args[0])
 			yieldValue := wiz.convertAst(node.Args[0])
-			fmt.Println("<-Arg:", node.Args[0])
 
 			yield, err := wiz.Render("yield", struct {
 				YieldValue string
@@ -353,23 +351,15 @@ func (wiz *FuncWizard) VisitIdent(node *ast.Ident) string {
 	}
 	definition, exists := wiz.pkg.TypesInfo.Defs[node]
 	if exists {
-		fmt.Println("exists", node)
-		name := wiz.DefineVariable(definition)
-		fmt.Println("as", name)
-		return name
+		return wiz.DefineVariable(definition)
 	}
-	fmt.Println("ident-node", node)
 	usage, exists := wiz.pkg.TypesInfo.Uses[node]
-	fmt.Println(usage, wiz.pkg.Fset.Position(usage.Pos()))
 	if _, isBuiltin := usage.(*types.Builtin); isBuiltin {
 		return node.String()
 	}
 	if exists && usage.Pkg() != nil && usage.Pkg().Path() == wiz.pkg.PkgPath {
-		name := wiz.GetVariable(usage)
-		fmt.Println("Name", name)
-		return name
+		return wiz.GetVariable(usage)
 	}
-	fmt.Println("node.string", node.String())
 	return node.String()
 }
 func (wiz *FuncWizard) VisitAssignStmt(node *ast.AssignStmt) string {

--- a/tests/issue_4.go
+++ b/tests/issue_4.go
@@ -1,0 +1,20 @@
+//go:build gengen
+
+package tests
+
+import (
+	"github.com/tmr232/gengen"
+)
+
+//go:generate go run github.com/tmr232/gengen/cmd/gengen
+
+func Issue4(stop int) gengen.Generator[int] {
+	for i := 0; i < stop; i++ {
+		gengen.Yield(i)
+	}
+
+	for i := stop; i >= 0; i-- {
+		gengen.Yield(i)
+	}
+	return nil
+}

--- a/tests/issue_4_test.go
+++ b/tests/issue_4_test.go
@@ -1,0 +1,36 @@
+package tests
+
+import (
+	"github.com/tmr232/gengen"
+	"reflect"
+	"testing"
+)
+
+func ToSlice[T any](gen gengen.Generator[T]) (slice []T) {
+	for gen.Next() {
+		slice = append(slice, gen.Value())
+	}
+	// TODO: Handle errors.
+	return
+}
+
+func TestIssue4(t *testing.T) {
+	type args struct {
+		n int
+	}
+	tests := []struct {
+		name string
+		args args
+		want []int
+	}{
+		{"2", args{2}, []int{0, 1, 2, 1, 0}},
+		{"10", args{10}, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToSlice(Issue4(tt.args.n)); !((len(got) == 0 && len(tt.want) == 0) || reflect.DeepEqual(got, tt.want)) {
+				t.Errorf("TakeN() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We had an issue where arguments to `gengen.Yield()` were printed as-is in the generated code.
As a result - no renaming of variables was happening with them, which caused issues.

We now solve this by using `wiz.convertAst` for the arguments passed to `gengen.Yield()`.
This could also be resolved by performing the renaming at the AST level, but we did not go down this path.
Mostly because for the time being - this is easier.

Additionally, we add handling for `ast.IndexExpr` nodes.
They are used in some of our tests, and as a result of this change - had to be handled for the tests to pass.

Closes #4 